### PR TITLE
Add --init option to git submodule update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ general:
 
 checkout:
   post:
-    - git submodule update --remote
+    - git submodule update --remote --init
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -19,5 +19,5 @@ dependencies:
 
 test:
   override:
-    - cd wp-e2e-tests && env BROWSERSIZE=desktop ./node_modules/mocha/bin/mocha --compilers js:babel-register specs-jetpack/ lib/after.js
     - cd wp-e2e-tests && env BROWSERSIZE=mobile ./node_modules/mocha/bin/mocha --compilers js:babel-register specs-jetpack/ lib/after.js
+    - cd wp-e2e-tests && env BROWSERSIZE=desktop ./node_modules/mocha/bin/mocha --compilers js:babel-register specs-jetpack/ lib/after.js


### PR DESCRIPTION
This handles the case where the wp-e2e-tests repo has not been initialized at all, requiring a fresh start.
