### PR TITLE
Added step to checkout (potentially) different branch from wp-e2e-tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,4 @@ dependencies:
 
 test:
   override:
-    - cd wp-e2e-tests && ./run.sh -R -j $RUN_ARGS
+    - cd wp-e2e-tests && git checkout origin/${E2E_BRANCH-master} && ./run.sh -R -j $RUN_ARGS


### PR DESCRIPTION
This enables the [trigger-circle-ci-specific.sh](https://github.com/Automattic/wp-e2e-tests/blob/master/scripts/trigger-circle-ci-specific.sh) functionality to pass a parameter to specify a non-master branch of the main wp-e2e-tests repo for testing purposes.