### PR TITLE
Remove npm pack / install reporter steps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,6 @@ dependencies:
   cache_directories:
     - "wp-e2e-tests/node_modules"
   override:
-    - cd wp-e2e-tests && npm pack lib/reporter
-    - cd wp-e2e-tests && npm install ./spec-xunit-slack-reporter-0.0.1.tgz
     - cd wp-e2e-tests && npm install
 
 test:


### PR DESCRIPTION
These steps are no longer necessary (having been moved to the postinstall step in package.json), and they caused breakage when I renamed the reporter in the master repo