### PR TITLE
Disable triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ workflows:
   commit:
     jobs:
       - build
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 1,13 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build
+#  nightly:
+#    triggers:
+#      - schedule:
+#          cron: "0 1,13 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
+#    jobs:
+#      - build


### PR DESCRIPTION
Triggers are being moved to wp-calypso in https://github.com/Automattic/wp-calypso/pull/31220